### PR TITLE
allow readOnly to be passed to CodeMirror

### DIFF
--- a/lib/AngularCodeMirror.js
+++ b/lib/AngularCodeMirror.js
@@ -30,7 +30,7 @@
 angular.module('AngularCodeMirrorModule', [])
 
     .factory('AngularCodeMirror', [ function() {
-        return function() {
+        return function(readOnly) {
             var fn = function() {
 
                 this.myCodeMirror = null;
@@ -68,6 +68,15 @@ angular.module('AngularCodeMirrorModule', [])
 
                     // Initialize CodeMirror
                     self.modes[mode].value = scope[model];
+                    
+                    // if readOnly is passed to AngularCodeMirror, set the
+                    // options for all modes to be readOnly
+                    if (readOnly) {
+                        Object.keys(self.modes).forEach(function(val) {
+                            self.modes[val].readOnly = true;
+                        });
+                    }
+                    
                     self.myCodeMirror = CodeMirror(document.getElementById('cm-' + model + '-container'), self.modes[mode]);
 
                     // Adjust the height


### PR DESCRIPTION
this allows a parameter to be passed into AngularCodeMirror to set the CodeMirror option of readOnly
